### PR TITLE
Allow `None` value object in `TagsWidget` to pass without error.

### DIFF
--- a/ELENA-NOTES
+++ b/ELENA-NOTES
@@ -1,0 +1,16 @@
+Schema isn't ideal for my use case.
+
+This project encourages:
+
+ *many* `contacts` attached to `companies`.
+
+My need is:
+
+ *many* `companies` (nominal `contacts`, but still excellent searchability)
+ *many* notes
+
+also: need to extend to facilitate `campaigns` of some kind.
+
+---
+
+Love the UI, but far enough off the mark (also not using standard django patterns) that effort probably better spent on my use case.

--- a/nublas/ui/widgets/tags.py
+++ b/nublas/ui/widgets/tags.py
@@ -18,11 +18,13 @@ class TagsWidget(forms.Widget):
                 final_attrs['class'] += ' %s' % v
             else:
                 final_attrs[k] = v
+        if value:
+            value = ','.join([ v.tag.name for v in value ])
         flat_attrs = forms.widgets.flatatt(self.build_attrs(final_attrs))
         errors = 'has-error' in final_attrs.get('class', '')
         return mark_safe(render_to_string(self.template, {
             'name': name,
-            'value': ','.join([ v.tag.name for v in value ]),
+            'value': value,
             'attrs': flat_attrs,
             'errors': errors,
         }))


### PR DESCRIPTION
Fixes bug reported here: https://github.com/kunitoki/nublas/issues/1
